### PR TITLE
Add script for Forestry previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 	"scripts": {
 		"build": "gatsby build",
 		"dev": "gatsby develop -H 0.0.0.0 -p 7777 -o",
+		"forestry:preview": "gatsby develop -H 0.0.0.0 - p 8080",
 		"format": "prettier --write 'src/**/*.js'",
 		"icons": "node src/utils/generateIcons.js"
 	},


### PR DESCRIPTION
@plhnk This should help fix the current issue you're facing with Instant Previews.

gatsby-cli is not installed globally on the default Node:10 Docker image, wrapping the default command in a npm script will help resolve the path issue.